### PR TITLE
Soothsayer Version 1.7.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soothsayer",
   "productName": "soothsayer",
-  "version": "1.7.21",
+  "version": "1.7.22",
   "description": "Soothsayer: A tool for generating OBS overlays for casting some video games.",
   "main": "src/index.js",
   "keywords": [],

--- a/src/components/data-grabbers/ngs.js
+++ b/src/components/data-grabbers/ngs.js
@@ -7,7 +7,7 @@ let divisions = {};
 let tournamentDivisions = {};
 let tournamentToDivision = {};
 let matches = {};
-const seasonID = 20;
+const seasonID = 21;
 
 const baseURL = 'https://www.nexusgamingseries.org/api';
 const imageURL = 'https://s3.amazonaws.com/ngs-image-storage';


### PR DESCRIPTION
Soothsayer V1.7.22 proposed changes:

update NGS.js season number to tell Soothsayer that NGS started a new Season
bump overall version to 1.7.22 due to ^

I am trying to set soothsayer up on my laptop, but I wanted to help you so that in case you updated Soothsayer, I wouldn't have to reinstall.

-Kaden from NGS